### PR TITLE
make AddReminder, and RemoveAllReminders functions available on plugin

### DIFF
--- a/lua/reminders/init.lua
+++ b/lua/reminders/init.lua
@@ -3,6 +3,9 @@ require("reminders.utils")
 require("plugin.reminders")
 local reminders = {}
 
+reminders.AddReminder = AddReminder
+reminders.RemoveAllReminders = RemoveAllReminders
+
 function reminders.setup(options)
 	options = options or {}
 	options.minute_interval = (options.minute_interval or 1) * 60 * 1000


### PR DESCRIPTION
Hi, I like your plugin, but I found that having these functions available helps me to better create a standard set of reminders during config.

There's probably some more functions that could be added for completeness, but I just kept it simple for now. 

If your curious this is my lazy config.

```lua
-- cSpell:ignore robgura rodolfojsv filereadable
return {
    -- 'rodolfojsv/reminders.nvim',
    'robgura/reminders.nvim',
    -- dir = '/home/dev/dev/reminders.nvim',
    config = function()
        -- create a remind directory for state storage
        local reminder_directory = vim.fn.stdpath("state") .. '/reminders.nvim'
        reminder_directory = vim.fn.resolve(reminder_directory)
        local reminder_json_file = reminder_directory .. '/reminders.json'
        reminder_json_file = vim.fn.resolve(reminder_json_file)

        if vim.fn.isdirectory(reminder_directory) ~= 1 then
            os.execute('mkdir -p ' .. reminder_directory)
        end

        local reminders = require('reminders')
        reminders.setup({
            directory_path = reminder_directory
        })

        local function load_reminders()
            reminders.AddReminder({
                reminderMsg = "Hydrate",
                remindEvery = "22",
                persistent = true,
                daily = false,
            })
            reminders.AddReminder({
                reminderMsg = "Scrum",
                remindAt = "9:28",
                persistent = true,
                daily = true,
            })
        end

        -- if there is no reminder file then create one with default events
        if vim.fn.filereadable(reminder_json_file) ~= 1 then
            load_reminders()
        end

        -- function to reload default events
        local function map_reload()
            reminders.RemoveAllReminders()
            load_reminders()
        end

        -- keymap to reload reminders file from source
        vim.keymap.set('n', '<leader>rr', map_reload, { desc = 'reload reminders from source control' } )
    end
}
```